### PR TITLE
Added a check for null values in the errors variable

### DIFF
--- a/acmevalidator.tests/acmevalidator.tests.csproj
+++ b/acmevalidator.tests/acmevalidator.tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>

--- a/acmevalidator.tests/acmevalidatortests.cs
+++ b/acmevalidator.tests/acmevalidatortests.cs
@@ -564,5 +564,33 @@ namespace acmevalidator.tests
 
             Assert.IsTrue(Validator.HasAllTheRequiredProperties(errors));
         }
+
+        [TestMethod]
+        public void HasAllTheRequiredPropertiesMethod_RequiredFieldMissingFromInput()
+        {
+            var acmevalidator = new Validator();
+            var input = new JObject
+            {
+                ["property1"] = new JObject
+                {
+                        { "subpropertyA", "value" },
+                        { "subpropertyB", "value" },
+                        { "subpropertyC", "value" }
+                }
+            };
+            var rules = new JObject
+            {
+                ["property1"] = new JObject
+                {
+                        { "subpropertyA", "$required" },
+                        { "subpropertyB", "$required" },
+                        { "subpropertyC", "$required" }
+                },
+                ["property2"] = "$required"
+            };
+            acmevalidator.Validate(input, rules, out Dictionary<JToken, JToken> errors);
+
+            Assert.IsFalse(Validator.HasAllTheRequiredProperties(errors));
+        }
     }
 }

--- a/acmevalidator/acmevalidator.cs
+++ b/acmevalidator/acmevalidator.cs
@@ -95,7 +95,6 @@ namespace acmevalidator
         public static bool HasAllTheRequiredProperties(Dictionary<JToken, JToken> errors)
         {
             bool hasAllTheRequiredProperties = true;
-
             if (errors.Count == 0)
             {
                 hasAllTheRequiredProperties = true;
@@ -104,6 +103,12 @@ namespace acmevalidator
             {
                 foreach (KeyValuePair<JToken, JToken> error in errors)
                 {
+                    if (error.Value == null)
+                    {
+                        hasAllTheRequiredProperties = false;
+                        break;
+                    }
+
                     foreach (JProperty child in error.Value.Children<JProperty>())
                     {
                         if (string.IsNullOrEmpty(child.Value.ToString()))


### PR DESCRIPTION
The changes done in this commit are:
- added a check for null values in the HasAllTheRequiredProperties method; this case occurs when there is a rule stating that a certain field is required, but the input to validate doesn't contain that field at all;
- added a unit test that covers this particular case;
- updated the Microsoft.NET.Test.Sdk to version 16.2.0